### PR TITLE
Get Session Data / Release Health Showing for iOS/Android

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -21,7 +21,6 @@ import CheckoutScreen from './screens/CheckoutScreen';
 import Toast from 'react-native-toast-message';
 
 import {store} from './reduxApp';
-import {version as packageVersion} from '../package.json';
 import {DSN} from './config';
 
 const reactNavigationV5Instrumentation = new Sentry.ReactNavigationV5Instrumentation(
@@ -33,7 +32,6 @@ const reactNavigationV5Instrumentation = new Sentry.ReactNavigationV5Instrumenta
 
 Sentry.init({
   dsn: DSN,
-  release: packageVersion,
   environment: "dev",
   beforeSend: (e) => {
     return e;
@@ -57,7 +55,6 @@ Sentry.init({
   sessionTrackingIntervalMillis: 5000,
   maxBreadcrumbs: 150, // Extend from the default 100 breadcrumbs.
   // debug: true
-  // dist: `${packageVersion}.0`, // optional.. Make sure this matches EXACTLY with the values on your sourcemaps
 });
 
 const Stack = createStackNavigator();


### PR DESCRIPTION
- Previously, we were seeing no session data showing up in the android and ios releases `2.0.5 (5)`.
- We were apparently setting the release manually. We now set the release automatically, which causes session data to show up.
- I think that this should also prevent there being a 'third release' (i.e. `2.0.6` with no build number) next time we increment the release number, but am not sure.

I ran the apps locally and took a few actions, causing session data to start showing:

![Screen Shot 2022-01-11 at 12 08 31 PM](https://user-images.githubusercontent.com/12092849/149013761-ab151b01-6ebd-46cc-84c9-8c79dc69c11b.png)
 