### PR TITLE
fix(promise): Fix promise package to enable rejection tracking 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@react-navigation/native": "^6.1.7",
         "@react-navigation/stack": "^6.3.17",
         "@sentry/react-native": "^5.9.1",
+        "promise": "^8.3.0",
         "react": "18.2.0",
         "react-native": "0.72.4",
         "react-native-dotenv": "^3.4.9",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "@react-navigation/native": "^6.1.7",
     "@react-navigation/stack": "^6.3.17",
     "@sentry/react-native": "^5.9.1",
+    "promise": "^8.3.0",
     "react": "18.2.0",
     "react-native": "0.72.4",
     "react-native-dotenv": "^3.4.9",


### PR DESCRIPTION
Promise rejection tracking only works if the package used by RN SDK is the same as the one used by RN. 

Some dep in this project use a promise package different than RN. This causes RN SDK rejection tracking to not work.
We have to install the same package as RN uses. 