### PR TITLE
fix(android): Build with stable `androidx.core`

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -3,6 +3,16 @@ apply plugin: "org.jetbrains.kotlin.android"
 apply plugin: "com.facebook.react"
 apply plugin: "io.sentry.android.gradle"
 
+// Dependency 'androidx.core:core:1.15.0-alpha01' requires libraries and applications that
+// depend on it to compile against version 35 or later of the
+// Android APIs.
+// Until resolved https://stackoverflow.com/questions/78626580/how-to-resolve-app-execution-failure-due-to-androidx-corecore1-15-0-alpha
+configurations.all {
+    resolutionStrategy {
+        force "androidx.core:core:1.13.1"
+    }
+}
+
 sentry {
     // Disables or enables the automatic configuration of Native Symbols
     // for Sentry. This executes sentry-cli automatically so


### PR DESCRIPTION
This PR fixes the following build error.

```
A failure occurred while executing com.android.build.gradle.internal.tasks.CheckAarMetadataWorkAction
   > An issue was found when checking AAR metadata:
       1.  Dependency 'androidx.core:core:1.15.0-alpha01' requires libraries and applications that
           depend on it to compile against version 35 or later of the
           Android APIs.
           :app is currently compiled against android-34.
           Also, the maximum recommended compile SDK version for Android Gradle
           plugin 8.2.1 is 34.
           Recommended action: Update this project's version of the Android Gradle
           plugin to one that supports 35, then update this project to use
           compileSdk of at least 35.
           Note that updating a library or application's compileSdk (which
           allows newer APIs to be used) can be done separately from updating
           targetSdk (which opts the app in to new runtime behavior) and
           minSdk (which determines which devices the app can be installed
           on).
* Try:
> Run with --stacktrace option to get the stack trace.
> Run with --info or --debug option to get more log output.
> Run with --scan to get full insights.
> Get more help at https://help.gradle.org.
```