### PR TITLE
ci(build): Add iOS APP and Android APK jobs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,10 +20,10 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 18
-          cache: 'yarn'
-          cache-dependency-path: yarn.lock
+          cache: 'npm'
+          cache-dependency-path: package-lock.json
 
-      - run: yarn
+      - run: npm ci
 
       - uses: actions/setup-java@v4
         with:
@@ -51,10 +51,10 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 18
-          cache: 'yarn'
-          cache-dependency-path: yarn.lock
+          cache: 'npm'
+          cache-dependency-path: package-lock.json
 
-      - run: yarn
+      - run: npm ci
 
       - uses: ruby/setup-ruby@v1
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -61,7 +61,7 @@ jobs:
           ruby-version: '3.3.0'
           bundler-cache: true # runs 'bundle install' and caches installed gems automatically
 
-      - working-directory: samples
+      - working-directory: ios
         run: bundle exec pod install
 
       - working-directory: ios

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,7 @@ on:
   pull_request:
 
 env:
-  SENTRY_ALLOW_FAILURE: true
+  SENTRY_ALLOW_FAILURE: false
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,93 @@
+name: Build
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-android:
+    name: Android
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 18
+          cache: 'yarn'
+          cache-dependency-path: yarn.lock
+
+      - run: yarn
+
+      - uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'adopt'
+
+      - uses: gradle/gradle-build-action@v3
+
+      - working-directory: android
+        run: ./gradlew :app:assembleRelease
+
+      - name: Upload APK
+        uses: actions/upload-artifact@v4
+        with:
+          name: empower-plant-react-native-android
+          path: android/app/build/outputs/apk/release/app-release.apk
+          retention-days: 60
+
+  build-ios:
+    name: iOS
+    runs-on: macos-14
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 18
+          cache: 'yarn'
+          cache-dependency-path: yarn.lock
+
+      - run: yarn
+
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.3.0'
+          bundler-cache: true # runs 'bundle install' and caches installed gems automatically
+
+      - working-directory: samples
+        run: bundle exec pod install
+
+      - working-directory: ios
+        run: |
+          mkdir -p "DerivedData"
+          derivedData="$(cd "DerivedData" ; pwd -P)"
+          set -o pipefail && xcodebuild \
+            -workspace sentry_react_native.xcworkspace \
+            -configuration "Release" \
+            -scheme sentry_react_native \
+            -destination 'generic/platform=iOS Simulator' \
+            -derivedDataPath "$derivedData" \
+            build \
+            | tee xcodebuild.log \
+            | xcbeautify --quieter --is-ci --disable-colored-output
+
+      - name: Upload APP
+        uses: actions/upload-artifact@v4
+        with:
+          name: empower-plant-react-native-ios
+          path: ios/DerivedData/Build/Products/Release-iphonesimulator/sentry_react_native.app
+          retention-days: 60
+
+      - name: Upload logs
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: build-ios-logs
+          path: ios/xcodebuild.log

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -64,7 +64,8 @@ jobs:
       - working-directory: ios
         run: bundle exec pod install
 
-      - working-directory: ios
+      - name: Run xcodebuild
+        working-directory: ios
         run: |
           mkdir -p "DerivedData"
           derivedData="$(cd "DerivedData" ; pwd -P)"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,6 +7,7 @@ on:
   pull_request:
 
 env:
+  SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
   SENTRY_ALLOW_FAILURE: false
 
 concurrency:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,6 +6,9 @@ on:
       - main
   pull_request:
 
+env:
+  SENTRY_ALLOW_FAILURE: true
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -150,7 +150,6 @@ android {
 dependencies {
     // The version of react-native is set by the React Native Gradle Plugin
     implementation("com.facebook.react:react-android")
-    implementation 'androidx.core:core-ktx:+'
 
     if (hermesEnabled.toBoolean()) {
         implementation("com.facebook.react:hermes-android")


### PR DESCRIPTION
This PR add a `Build` workflow with `iOS` and `Android` jobs.

The jobs build Release versions of the app without signing to run on generic emulators.

The APK and APP is uploaded as an artefact with 2 months retention.

### 🧑‍🏭 Todo:
- [x] Add `SENTRY_AUTH_TOKEN` to CI secrets for debug files upload
- [x] Remove `SENTRY_ALLOW_FAILURE` to ensure debug files are always uploaded (failure allowed to test the build jobs)