### PR TITLE
fix(ci): Use master, main does not exist

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,7 +3,7 @@ name: Build
 on:
   push:
     branches:
-      - main
+      - master
   pull_request:
 
 env:


### PR DESCRIPTION
Small follow up to the recently added CI, this repo is still using master naming for main.