### PR TITLE
 fix: Missing branches for merge and push to master

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,30 +74,30 @@ jobs:
         with:
           fetch-depth: 0 # fetch all history all branches and tags
 
-      - name: Download iOS App
-        uses: actions/download-artifact@v4
-        with:
-          name: empower-plant-react-native-ios
+      # - name: Download iOS App
+      #   uses: actions/download-artifact@v4
+      #   with:
+      #     name: empower-plant-react-native-ios
 
-      - name: Download Android APK
-        uses: actions/download-artifact@v4
-        with:
-          name: empower-plant-react-native-android
+      # - name: Download Android APK
+      #   uses: actions/download-artifact@v4
+      #   with:
+      #     name: empower-plant-react-native-android
 
       - name: Set GitHub user
         run: |
           git config user.name getsentry-bot
           git config user.email bot@sentry.io
 
-      - name: Create Release
-        run: |
-          gh release create \
-            ${{ env.VERSION }} \
-            ${{ env.APK_PATH }} \
-            ${{ env.APP_ARCHIVE_PATH }} \
-            --title ${{ env.VERSION }} \
-            --notes "Release ${{ env.VERSION }}" \
-            || error_exit "Failed to create GitHub release."
+      # - name: Create Release
+      #   run: |
+      #     gh release create \
+      #       ${{ env.VERSION }} \
+      #       ${{ env.APK_PATH }} \
+      #       ${{ env.APP_ARCHIVE_PATH }} \
+      #       --title ${{ env.VERSION }} \
+      #       --notes "Release ${{ env.VERSION }}" \
+      #       || error_exit "Failed to create GitHub release."
 
       - name: Merge Release
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,7 +61,7 @@ jobs:
 
   publish-release:
     name: 'Publish Release'
-    # needs: [bump-version, build-android, build-ios]
+    # needs: [bump-version, build-android]
     runs-on: ubuntu-latest
     env:
       MERGE_TARGET: master-test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -104,5 +104,5 @@ jobs:
           git reset --hard
           git checkout release/${{ env.VERSION }}
           git checkout ${{ env.MERGE_TARGET }}
-          git merge release/${{ env.VERSION }}
+          git merge release/${{ env.VERSION }} --no-ff
           git push origin ${{ env.MERGE_TARGET }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,5 @@
 name: Release
 on:
-  pull_request:
   workflow_dispatch:
     inputs:
       version:
@@ -13,55 +12,55 @@ env:
   GH_TOKEN: ${{ github.token }}
 
 jobs:
-  # bump-version:
-  #   runs-on: ubuntu-latest
-  #   name: 'Prepare Release'
-  #   steps:
-  #     - name: Set environment variables
-  #       run: |
-  #         echo "VERSION=${{ inputs.version }}" >> $GITHUB_ENV
+  bump-version:
+    runs-on: ubuntu-latest
+    name: 'Prepare Release'
+    steps:
+      - name: Set environment variables
+        run: |
+          echo "VERSION=${{ inputs.version }}" >> $GITHUB_ENV
 
-  #     - uses: actions/checkout@v4
+      - uses: actions/checkout@v4
 
-  #     - uses: actions/setup-node@v4
-  #       with:
-  #         node-version: 18
-  #         cache: 'npm'
-  #         cache-dependency-path: package-lock.json
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 18
+          cache: 'npm'
+          cache-dependency-path: package-lock.json
 
-  #     - name: Install dependencies
-  #       run: npm ci
+      - name: Install dependencies
+        run: npm ci
 
-  #     - name: Bump Version
-  #       run: |
-  #         git config user.name getsentry-bot
-  #         git config user.email bot@sentry.io
+      - name: Bump Version
+        run: |
+          git config user.name getsentry-bot
+          git config user.email bot@sentry.io
 
-  #         git checkout -b release/${{ env.VERSION }}
-  #         npm version ${{ env.VERSION }}
-  #         git tag --force ${{ env.VERSION }} -m ${{ env.VERSION }}
-  #         git push origin ${{ env.VERSION }}
-  #         git push origin release/${{ env.VERSION }}
+          git checkout -b release/${{ env.VERSION }}
+          npm version ${{ env.VERSION }}
+          git tag --force ${{ env.VERSION }} -m ${{ env.VERSION }}
+          git push origin ${{ env.VERSION }}
+          git push origin release/${{ env.VERSION }}
 
-  # build-android:
-  #   name: 'Build Android'
-  #   needs: [bump-version]
-  #   uses: ./.github/workflows/build-android.yml
-  #   secrets: inherit
-  #   with:
-  #     ref: release/${{ inputs.version }}
+  build-android:
+    name: 'Build Android'
+    needs: [bump-version]
+    uses: ./.github/workflows/build-android.yml
+    secrets: inherit
+    with:
+      ref: release/${{ inputs.version }}
 
-  # build-ios:
-  #   name: 'Build iOS'
-  #   needs: [bump-version]
-  #   uses: ./.github/workflows/build-ios.yml
-  #   secrets: inherit
-  #   with:
-  #     ref: release/${{ inputs.version }}
+  build-ios:
+    name: 'Build iOS'
+    needs: [bump-version]
+    uses: ./.github/workflows/build-ios.yml
+    secrets: inherit
+    with:
+      ref: release/${{ inputs.version }}
 
   publish-release:
     name: 'Publish Release'
-    # needs: [bump-version, build-android]
+    needs: [bump-version, build-android]
     runs-on: ubuntu-latest
     env:
       MERGE_TARGET: master-test
@@ -74,30 +73,30 @@ jobs:
         with:
           fetch-depth: 0 # fetch all history all branches and tags
 
-      # - name: Download iOS App
-      #   uses: actions/download-artifact@v4
-      #   with:
-      #     name: empower-plant-react-native-ios
+      - name: Download iOS App
+        uses: actions/download-artifact@v4
+        with:
+          name: empower-plant-react-native-ios
 
-      # - name: Download Android APK
-      #   uses: actions/download-artifact@v4
-      #   with:
-      #     name: empower-plant-react-native-android
+      - name: Download Android APK
+        uses: actions/download-artifact@v4
+        with:
+          name: empower-plant-react-native-android
 
       - name: Set GitHub user
         run: |
           git config user.name getsentry-bot
           git config user.email bot@sentry.io
 
-      # - name: Create Release
-      #   run: |
-      #     gh release create \
-      #       ${{ env.VERSION }} \
-      #       ${{ env.APK_PATH }} \
-      #       ${{ env.APP_ARCHIVE_PATH }} \
-      #       --title ${{ env.VERSION }} \
-      #       --notes "Release ${{ env.VERSION }}" \
-      #       || error_exit "Failed to create GitHub release."
+      - name: Create Release
+        run: |
+          gh release create \
+            ${{ env.VERSION }} \
+            ${{ env.APK_PATH }} \
+            ${{ env.APP_ARCHIVE_PATH }} \
+            --title ${{ env.VERSION }} \
+            --notes "Release ${{ env.VERSION }}" \
+            || error_exit "Failed to create GitHub release."
 
       - name: Merge Release
         run: |
@@ -106,3 +105,4 @@ jobs:
           git checkout ${{ env.MERGE_TARGET }}
           git merge release/${{ env.VERSION }} --no-ff
           git push origin ${{ env.MERGE_TARGET }}
+          git push origin --delete release/${{ env.VERSION }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,7 +60,7 @@ jobs:
 
   publish-release:
     name: 'Publish Release'
-    needs: [bump-version, build-android]
+    needs: [bump-version, build-android, build-ios]
     runs-on: ubuntu-latest
     env:
       MERGE_TARGET: master

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,11 +63,11 @@ jobs:
     needs: [bump-version, build-android]
     runs-on: ubuntu-latest
     env:
-      MERGE_TARGET: master-test
+      MERGE_TARGET: master
     steps:
       - name: Set environment variables
         run: |
-          echo "VERSION=${{ inputs.version || '3.1.0' }}" >> $GITHUB_ENV
+          echo "VERSION=${{ inputs.version }}" >> $GITHUB_ENV
 
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,7 +61,7 @@ jobs:
 
   publish-release:
     name: 'Publish Release'
-    needs: [bump-version, build-android, build-ios]
+    # needs: [bump-version, build-android, build-ios]
     runs-on: ubuntu-latest
     env:
       MERGE_TARGET: master-test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,6 @@
 name: Release
 on:
+  pull_request:
   workflow_dispatch:
     inputs:
       version:
@@ -12,66 +13,66 @@ env:
   GH_TOKEN: ${{ github.token }}
 
 jobs:
-  bump-version:
-    runs-on: ubuntu-latest
-    name: 'Prepare Release'
-    steps:
-      - name: Set environment variables
-        run: |
-          echo "VERSION=${{ inputs.version }}" >> $GITHUB_ENV
+  # bump-version:
+  #   runs-on: ubuntu-latest
+  #   name: 'Prepare Release'
+  #   steps:
+  #     - name: Set environment variables
+  #       run: |
+  #         echo "VERSION=${{ inputs.version }}" >> $GITHUB_ENV
 
-      - uses: actions/checkout@v4
+  #     - uses: actions/checkout@v4
 
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 18
-          cache: 'npm'
-          cache-dependency-path: package-lock.json
+  #     - uses: actions/setup-node@v4
+  #       with:
+  #         node-version: 18
+  #         cache: 'npm'
+  #         cache-dependency-path: package-lock.json
 
-      - name: Install dependencies
-        run: npm ci
+  #     - name: Install dependencies
+  #       run: npm ci
 
-      - name: Bump Version
-        run: |
-          git config user.name getsentry-bot
-          git config user.email bot@sentry.io
+  #     - name: Bump Version
+  #       run: |
+  #         git config user.name getsentry-bot
+  #         git config user.email bot@sentry.io
 
-          git checkout -b release/${{ env.VERSION }}
-          npm version ${{ env.VERSION }}
-          git tag --force ${{ env.VERSION }} -m ${{ env.VERSION }}
-          git push origin ${{ env.VERSION }}
-          git push origin release/${{ env.VERSION }}
+  #         git checkout -b release/${{ env.VERSION }}
+  #         npm version ${{ env.VERSION }}
+  #         git tag --force ${{ env.VERSION }} -m ${{ env.VERSION }}
+  #         git push origin ${{ env.VERSION }}
+  #         git push origin release/${{ env.VERSION }}
 
-  build-android:
-    name: 'Build Android'
-    needs: [bump-version]
-    uses: ./.github/workflows/build-android.yml
-    secrets: inherit
-    with:
-      ref: release/${{ inputs.version }}
+  # build-android:
+  #   name: 'Build Android'
+  #   needs: [bump-version]
+  #   uses: ./.github/workflows/build-android.yml
+  #   secrets: inherit
+  #   with:
+  #     ref: release/${{ inputs.version }}
 
-  build-ios:
-    name: 'Build iOS'
-    needs: [bump-version]
-    uses: ./.github/workflows/build-ios.yml
-    secrets: inherit
-    with:
-      ref: release/${{ inputs.version }}
+  # build-ios:
+  #   name: 'Build iOS'
+  #   needs: [bump-version]
+  #   uses: ./.github/workflows/build-ios.yml
+  #   secrets: inherit
+  #   with:
+  #     ref: release/${{ inputs.version }}
 
   publish-release:
     name: 'Publish Release'
     needs: [bump-version, build-android, build-ios]
     runs-on: ubuntu-latest
     env:
-      MERGE_TARGET: master
+      MERGE_TARGET: master-test
     steps:
       - name: Set environment variables
         run: |
-          echo "VERSION=${{ inputs.version }}" >> $GITHUB_ENV
+          echo "VERSION=${{ inputs.version || '3.1.0' }}" >> $GITHUB_ENV
 
       - uses: actions/checkout@v4
         with:
-          ref: ${{ env.MERGE_TARGET }}
+          fetch-depth: 0 # fetch all history all branches and tags
 
       - name: Download iOS App
         uses: actions/download-artifact@v4
@@ -100,6 +101,8 @@ jobs:
 
       - name: Merge Release
         run: |
-          git merge release/${{ env.VERSION }} \
-            && git push origin ${{ env.MERGE_TARGET }} \
-            || gh pr create --title "Merge Release ${{ env.VERSION }}" --body "Merge of the release ${{ env.VERSION }} into ${{ env.MERGE_TARGET }} failed. Please it merge manually."
+          git reset --hard
+          git checkout release/${{ env.VERSION }}
+          git checkout ${{ env.MERGE_TARGET }}
+          git merge release/${{ env.VERSION }}
+          git push origin ${{ env.MERGE_TARGET }}


### PR DESCRIPTION
This PR fixes automatic merge after a release.

The previous version failed because not all branches were fetched. The CI job could not merge the release branch with the master.

This PR also cleans up the release branch after a successful merge.