### PR TITLE
Release 3.1.0

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -119,8 +119,8 @@ android {
         applicationId "com.sentry_react_native"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 17
-        versionName "3.0.0"
+        versionCode 18
+        versionName "3.1.0"
     }
     signingConfigs {
         debug {

--- a/ios/sentry_react_native.xcodeproj/project.pbxproj
+++ b/ios/sentry_react_native.xcodeproj/project.pbxproj
@@ -484,7 +484,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
-				CURRENT_PROJECT_VERSION = 17;
+				CURRENT_PROJECT_VERSION = 18;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = sentry_react_native/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -511,7 +511,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
-				CURRENT_PROJECT_VERSION = 17;
+				CURRENT_PROJECT_VERSION = 18;
 				INFOPLIST_FILE = sentry_react_native/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",

--- a/ios/sentry_react_native/Info.plist
+++ b/ios/sentry_react_native/Info.plist
@@ -17,20 +17,19 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.0.0</string>
+	<string>3.1.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>17</string>
+	<string>18</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true />
 	<key>NSAppTransportSecurity</key>
 	<dict>
-		<!-- Do not change NSAllowsArbitraryLoads to true, or you will risk app rejection! -->
 		<key>NSAllowsArbitraryLoads</key>
-		<false/>
+		<false />
 		<key>NSAllowsLocalNetworking</key>
-		<true/>
+		<true />
 	</dict>
 	<key>NSLocationWhenInUseUsageDescription</key>
 	<string />

--- a/ios/sentry_react_nativeTests/Info.plist
+++ b/ios/sentry_react_nativeTests/Info.plist
@@ -15,10 +15,10 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.0.0</string>
+	<string>3.1.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>17</string>
+	<string>18</string>
 </dict>
 </plist>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sentry_react_native",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sentry_react_native",
-      "version": "3.0.0",
+      "version": "3.1.0",
       "hasInstallScript": true,
       "dependencies": {
         "@react-navigation/bottom-tabs": "^6.5.20",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sentry_react_native",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "private": true,
   "scripts": {
     "android": "react-native run-android",


### PR DESCRIPTION
https://github.com/sentry-demos/sentry_react_native/releases/tag/3.1.0

Release done by CI, https://github.com/sentry-demos/sentry_react_native/actions/runs/13281271997/job/37080749354

But merge to master failed. So we need to do it manually this time.