### PR TITLE
fix(ci): Release should wait for iOS build to finish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,7 +60,7 @@ jobs:
 
   publish-release:
     name: 'Publish Release'
-    needs: [bump-version, build-android]
+    needs: [bump-version, build-android, build-ios]
     runs-on: ubuntu-latest
     env:
       MERGE_TARGET: master


### PR DESCRIPTION
The Release Publish job was not waiting for iOS to finish building.

