### PR TITLE
Use 999.0.0 as development version and do not merge releases to main

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,10 +78,10 @@ jobs:
       #   with:
       #     name: empower-plant-react-native-ios
 
-      # - name: Download Android APK
-      #   uses: actions/download-artifact@v4
-      #   with:
-      #     name: empower-plant-react-native-android
+      - name: Download Android APK
+        uses: actions/download-artifact@v4
+        with:
+          name: empower-plant-react-native-android
 
       - name: Set GitHub user
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -98,11 +98,9 @@ jobs:
             --notes "Release ${{ env.VERSION }}" \
             || error_exit "Failed to create GitHub release."
 
-      - name: Merge Release
+      - name: Clean up Release Branch
         run: |
           git reset --hard
-          git checkout release/${{ env.VERSION }}
           git checkout ${{ env.MERGE_TARGET }}
-          git merge release/${{ env.VERSION }} --no-ff
-          git push origin ${{ env.MERGE_TARGET }}
+          git branch --delete release/${{ env.VERSION }}
           git push origin --delete release/${{ env.VERSION }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -102,5 +102,4 @@ jobs:
         run: |
           git reset --hard
           git checkout ${{ env.MERGE_TARGET }}
-          git branch --delete release/${{ env.VERSION }}
           git push origin --delete release/${{ env.VERSION }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,17 +50,17 @@ jobs:
     with:
       ref: release/${{ inputs.version }}
 
-  build-ios:
-    name: 'Build iOS'
-    needs: [bump-version]
-    uses: ./.github/workflows/build-ios.yml
-    secrets: inherit
-    with:
-      ref: release/${{ inputs.version }}
+  # build-ios:
+  #   name: 'Build iOS'
+  #   needs: [bump-version]
+  #   uses: ./.github/workflows/build-ios.yml
+  #   secrets: inherit
+  #   with:
+  #     ref: release/${{ inputs.version }}
 
   publish-release:
     name: 'Publish Release'
-    needs: [bump-version, build-android, build-ios]
+    needs: [bump-version, build-android]
     runs-on: ubuntu-latest
     env:
       MERGE_TARGET: master
@@ -73,10 +73,10 @@ jobs:
         with:
           fetch-depth: 0 # fetch all history all branches and tags
 
-      - name: Download iOS App
-        uses: actions/download-artifact@v4
-        with:
-          name: empower-plant-react-native-ios
+      # - name: Download iOS App
+      #   uses: actions/download-artifact@v4
+      #   with:
+      #     name: empower-plant-react-native-ios
 
       - name: Download Android APK
         uses: actions/download-artifact@v4
@@ -93,7 +93,7 @@ jobs:
           gh release create \
             ${{ env.VERSION }} \
             ${{ env.APK_PATH }} \
-            ${{ env.APP_ARCHIVE_PATH }} \
+            # ${{ env.APP_ARCHIVE_PATH }} \
             --title ${{ env.VERSION }} \
             --notes "Release ${{ env.VERSION }}" \
             || error_exit "Failed to create GitHub release."

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,10 +78,10 @@ jobs:
       #   with:
       #     name: empower-plant-react-native-ios
 
-      - name: Download Android APK
-        uses: actions/download-artifact@v4
-        with:
-          name: empower-plant-react-native-android
+      # - name: Download Android APK
+      #   uses: actions/download-artifact@v4
+      #   with:
+      #     name: empower-plant-react-native-android
 
       - name: Set GitHub user
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,13 +42,13 @@ jobs:
           git push origin ${{ env.VERSION }}
           git push origin release/${{ env.VERSION }}
 
-  build-android:
-    name: 'Build Android'
-    needs: [bump-version]
-    uses: ./.github/workflows/build-android.yml
-    secrets: inherit
-    with:
-      ref: release/${{ inputs.version }}
+  # build-android:
+  #   name: 'Build Android'
+  #   needs: [bump-version]
+  #   uses: ./.github/workflows/build-android.yml
+  #   secrets: inherit
+  #   with:
+  #     ref: release/${{ inputs.version }}
 
   # build-ios:
   #   name: 'Build iOS'
@@ -60,7 +60,7 @@ jobs:
 
   publish-release:
     name: 'Publish Release'
-    needs: [bump-version, build-android]
+    needs: [bump-version]
     runs-on: ubuntu-latest
     env:
       MERGE_TARGET: master
@@ -92,8 +92,6 @@ jobs:
         run: |
           gh release create \
             ${{ env.VERSION }} \
-            ${{ env.APK_PATH }} \
-            # ${{ env.APP_ARCHIVE_PATH }} \
             --title ${{ env.VERSION }} \
             --notes "Release ${{ env.VERSION }}" \
             || error_exit "Failed to create GitHub release."

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,17 +50,17 @@ jobs:
     with:
       ref: release/${{ inputs.version }}
 
-  # build-ios:
-  #   name: 'Build iOS'
-  #   needs: [bump-version]
-  #   uses: ./.github/workflows/build-ios.yml
-  #   secrets: inherit
-  #   with:
-  #     ref: release/${{ inputs.version }}
+  build-ios:
+    name: 'Build iOS'
+    needs: [bump-version]
+    uses: ./.github/workflows/build-ios.yml
+    secrets: inherit
+    with:
+      ref: release/${{ inputs.version }}
 
   publish-release:
     name: 'Publish Release'
-    needs: [bump-version, build-android]
+    needs: [bump-version, build-android, build-ios]
     runs-on: ubuntu-latest
     env:
       MERGE_TARGET: master
@@ -73,10 +73,10 @@ jobs:
         with:
           fetch-depth: 0 # fetch all history all branches and tags
 
-      # - name: Download iOS App
-      #   uses: actions/download-artifact@v4
-      #   with:
-      #     name: empower-plant-react-native-ios
+      - name: Download iOS App
+        uses: actions/download-artifact@v4
+        with:
+          name: empower-plant-react-native-ios
 
       - name: Download Android APK
         uses: actions/download-artifact@v4
@@ -93,7 +93,7 @@ jobs:
           gh release create \
             ${{ env.VERSION }} \
             ${{ env.APK_PATH }} \
-            # ${{ env.APP_ARCHIVE_PATH }} \
+            ${{ env.APP_ARCHIVE_PATH }} \
             --title ${{ env.VERSION }} \
             --notes "Release ${{ env.VERSION }}" \
             || error_exit "Failed to create GitHub release."

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,13 +42,13 @@ jobs:
           git push origin ${{ env.VERSION }}
           git push origin release/${{ env.VERSION }}
 
-  # build-android:
-  #   name: 'Build Android'
-  #   needs: [bump-version]
-  #   uses: ./.github/workflows/build-android.yml
-  #   secrets: inherit
-  #   with:
-  #     ref: release/${{ inputs.version }}
+  build-android:
+    name: 'Build Android'
+    needs: [bump-version]
+    uses: ./.github/workflows/build-android.yml
+    secrets: inherit
+    with:
+      ref: release/${{ inputs.version }}
 
   # build-ios:
   #   name: 'Build iOS'
@@ -60,7 +60,7 @@ jobs:
 
   publish-release:
     name: 'Publish Release'
-    needs: [bump-version]
+    needs: [bump-version, build-android]
     runs-on: ubuntu-latest
     env:
       MERGE_TARGET: master
@@ -92,6 +92,8 @@ jobs:
         run: |
           gh release create \
             ${{ env.VERSION }} \
+            ${{ env.APK_PATH }} \
+            # ${{ env.APP_ARCHIVE_PATH }} \
             --title ${{ env.VERSION }} \
             --notes "Release ${{ env.VERSION }}" \
             || error_exit "Failed to create GitHub release."

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -119,8 +119,8 @@ android {
         applicationId "com.sentry_react_native"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 18
-        versionName "3.1.0"
+        versionCode 19
+        versionName "999.0.0"
     }
     signingConfigs {
         debug {

--- a/ios/sentry_react_native.xcodeproj/project.pbxproj
+++ b/ios/sentry_react_native.xcodeproj/project.pbxproj
@@ -484,7 +484,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
-				CURRENT_PROJECT_VERSION = 18;
+				CURRENT_PROJECT_VERSION = 19;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = sentry_react_native/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -511,7 +511,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
-				CURRENT_PROJECT_VERSION = 18;
+				CURRENT_PROJECT_VERSION = 19;
 				INFOPLIST_FILE = sentry_react_native/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",

--- a/ios/sentry_react_native/Info.plist
+++ b/ios/sentry_react_native/Info.plist
@@ -17,11 +17,11 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.1.0</string>
+	<string>999.0.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>18</string>
+	<string>19</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true />
 	<key>NSAppTransportSecurity</key>

--- a/ios/sentry_react_nativeTests/Info.plist
+++ b/ios/sentry_react_nativeTests/Info.plist
@@ -15,10 +15,10 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.1.0</string>
+	<string>999.0.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>18</string>
+	<string>19</string>
 </dict>
 </plist>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sentry_react_native",
-  "version": "3.1.0",
+  "version": "999.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sentry_react_native",
-      "version": "3.1.0",
+      "version": "999.0.0",
       "hasInstallScript": true,
       "dependencies": {
         "@react-navigation/bottom-tabs": "^6.5.20",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sentry_react_native",
-  "version": "3.1.0",
+  "version": "999.0.0",
   "private": true,
   "scripts": {
     "android": "react-native run-android",


### PR DESCRIPTION
Since the configuration of auto merging to the main branch with the correct permission requires more work than expected.

I adjusted the CI job to not merge the release branch but just clean it up at the end of the job.

The master branch will contain version 999.0.0 marking a development version.