### PR TITLE
feat: Unmask button text for session replay

### DIFF
--- a/src/components/UserFeedbackModal.tsx
+++ b/src/components/UserFeedbackModal.tsx
@@ -44,8 +44,12 @@ export const SentryUserFeedbackActionButton = () => {
     <>
       {feedbackState.isActionButtonVisible && (
         <Pressable onPress={onGiveFeedbackButtonPress} style={pressableStyle}>
-          <Icon name="bug" size={24} color="#fff" />
-          <Text style={style.text}>Report a Bug</Text>
+          <Sentry.Unmask>
+            <Icon name="bug" size={24} color="#fff" />
+          </Sentry.Unmask>
+          <Sentry.Unmask>
+            <Text style={style.text}>Report a Bug</Text>
+          </Sentry.Unmask>
         </Pressable>
       )}
       {isFormVisible && (

--- a/src/screens/ListApp.tsx
+++ b/src/screens/ListApp.tsx
@@ -158,42 +158,54 @@ const ListApp = (props: Props) => {
               onPress={() => {
                 Sentry.captureMessage('Test Message');
               }}>
-              <Text style={styles.buttonText}>Capture Message</Text>
+              <Sentry.Unmask>
+                <Text style={styles.buttonText}>Capture Message</Text>
+              </Sentry.Unmask>
             </TouchableOpacity>
             <View style={styles.spacer} />
             <TouchableOpacity
               onPress={() => {
                 Sentry.captureException(new Error('Test Error'));
               }}>
-              <Text style={styles.buttonText}>Capture Exception</Text>
+              <Sentry.Unmask>
+                <Text style={styles.buttonText}>Capture Exception</Text>
+              </Sentry.Unmask>
             </TouchableOpacity>
             <View style={styles.spacer} />
             <TouchableOpacity
               onPress={() => {
                 throw new Error('Thrown Error');
               }}>
-              <Text style={styles.buttonText}>Uncaught Thrown Error</Text>
+              <Sentry.Unmask>
+                <Text style={styles.buttonText}>Uncaught Thrown Error</Text>
+              </Sentry.Unmask>
             </TouchableOpacity>
             <View style={styles.spacer} />
             <TouchableOpacity
               onPress={() => {
                 Promise.reject(new Error('Unhandled Promise Rejection'));
               }}>
-              <Text style={styles.buttonText}>Unhandled Promise Rejection</Text>
+              <Sentry.Unmask>
+                <Text style={styles.buttonText}>Unhandled Promise Rejection</Text>
+              </Sentry.Unmask>
             </TouchableOpacity>
             <View style={styles.spacer} />
             <TouchableOpacity
               onPress={() => {
                 Sentry.nativeCrash();
               }}>
-              <Text style={styles.buttonText}>Native Crash</Text>
+              <Sentry.Unmask>
+                <Text style={styles.buttonText}>Native Crash</Text>
+              </Sentry.Unmask>
             </TouchableOpacity>
             <View style={styles.spacer} />
             <TouchableOpacity
               onPress={() => {
                 setScopeProps();
               }}>
-              <Text style={styles.buttonText}>Set Scope Properties</Text>
+              <Sentry.Unmask>
+                <Text style={styles.buttonText}>Set Scope Properties</Text>
+              </Sentry.Unmask>
             </TouchableOpacity>
             <View style={styles.spacer} />
             <Sentry.ErrorBoundary
@@ -204,9 +216,11 @@ const ListApp = (props: Props) => {
                 onPress={() => {
                   setShowBadCode(true);
                 }}>
-                <Text style={styles.buttonText}>
-                  Activate Error Boundary {showBadCode && <div />}
-                </Text>
+                <Sentry.Unmask>
+                  <Text style={styles.buttonText}>
+                    Activate Error Boundary {showBadCode && <div />}
+                  </Text>
+                </Sentry.Unmask>
               </TouchableOpacity>
             </Sentry.ErrorBoundary>
           </View>
@@ -215,14 +229,18 @@ const ListApp = (props: Props) => {
               onPress={() => {
                 props.navigation.navigate('Tracker');
               }}>
-              <Text style={styles.buttonText}>Auto Tracing Example</Text>
+              <Sentry.Unmask>
+                <Text style={styles.buttonText}>Auto Tracing Example</Text>
+              </Sentry.Unmask>
             </TouchableOpacity>
             <View style={styles.spacer} />
             <TouchableOpacity
               onPress={() => {
                 props.navigation.navigate('ManualTracker');
               }}>
-              <Text style={styles.buttonText}>Manual Tracing Example</Text>
+              <Sentry.Unmask>
+                <Text style={styles.buttonText}>Manual Tracing Example</Text>
+              </Sentry.Unmask>
             </TouchableOpacity>
             <View style={styles.spacer} />
             <TouchableOpacity
@@ -241,14 +259,18 @@ const ListApp = (props: Props) => {
                   }),
                 );
               }}>
-              <Text style={styles.buttonText}>Performance Timing</Text>
+              <Sentry.Unmask>
+                <Text style={styles.buttonText}>Performance Timing</Text>
+              </Sentry.Unmask>
             </TouchableOpacity>
             <View style={styles.spacer} />
             <TouchableOpacity
               onPress={() => {
                 props.navigation.navigate('Redux');
               }}>
-              <Text style={styles.buttonText}>Redux Example</Text>
+              <Sentry.Unmask>
+                <Text style={styles.buttonText}>Redux Example</Text>
+              </Sentry.Unmask>
             </TouchableOpacity>
           </View>
         </View>


### PR DESCRIPTION
Wrap button labels with `Sentry.Unmask` in `ListApp.tsx` so they remain visible in session replays.

Before
<img width="548" height="492" alt="Screenshot 2026-03-19 at 10 30 02 AM" src="https://github.com/user-attachments/assets/80ee303a-471a-494a-b4e7-37d17e2d490c" />

After
<img width="560" height="488" alt="Screenshot 2026-03-19 at 10 29 48 AM" src="https://github.com/user-attachments/assets/319378b0-23b4-450d-85ab-9f5c67385035" />

<img width="680" height="336" alt="Screenshot 2026-03-19 at 10 58 48 AM" src="https://github.com/user-attachments/assets/a2cbafd9-838e-4812-baaf-be1d9c0ffcd8" />



Made with [Cursor](https://cursor.com)