### PR TITLE
sdk bump to 8.8.0

### DIFF
--- a/.github/workflows/build-ios.yml
+++ b/.github/workflows/build-ios.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   build-ios:
     name: iOS
-    runs-on: macos-14
+    runs-on: macos-15
     env:
       APP_ARCHIVE_PATH: sentry_react_native.app.zip
       SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -17,7 +17,7 @@ buildscript {
         classpath("com.android.tools.build:gradle")
         classpath("com.facebook.react:react-native-gradle-plugin")
         classpath("org.jetbrains.kotlin:kotlin-gradle-plugin")
-        classpath("io.sentry:sentry-android-gradle-plugin:3.12.0")
+        classpath("io.sentry:sentry-android-gradle-plugin:6.0.0")
     }
 }
 

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1806,7 +1806,7 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
-  - RNSentry (7.8.0):
+  - RNSentry (8.8.0):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -1829,7 +1829,7 @@ PODS:
     - ReactCodegen
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
-    - Sentry/HybridSDK (= 8.57.3)
+    - Sentry (= 9.10.0)
     - Yoga
   - RNVectorIcons (10.1.0):
     - DoubleConversion
@@ -1855,7 +1855,9 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
-  - Sentry/HybridSDK (8.57.3)
+  - Sentry (9.10.0):
+    - Sentry/Core (= 9.10.0)
+  - Sentry/Core (9.10.0)
   - SocketRocket (0.7.1)
   - Yoga (0.0.0)
 
@@ -2173,9 +2175,9 @@ SPEC CHECKSUMS:
   ReactCommon: 76d2dc87136d0a667678668b86f0fca0c16fdeb0
   RNGestureHandler: ebef699ea17e7c0006c1074e1e423ead60ce0121
   RNScreens: 5621e3ad5a329fbd16de683344ac5af4192b40d3
-  RNSentry: 4b60223daf66cf8571e1b0d883f4d3d1fc7d6e06
+  RNSentry: b34e301182b6a5933fbf8e21721dc3809b53aa75
   RNVectorIcons: 22dad8b187479d5dee8e56e8a2f2b1c11c5910a0
-  Sentry: c643eb180df401dd8c734c5036ddd9dd9218daa6
+  Sentry: 4e85b40e4b0235853f40f959d315a6b28e3148d8
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748
   Yoga: c758bfb934100bb4bf9cbaccb52557cee35e8bdf
 

--- a/ios/sentry_react_native.xcodeproj/project.pbxproj
+++ b/ios/sentry_react_native.xcodeproj/project.pbxproj
@@ -341,7 +341,7 @@
 					"$(inherited)",
 				);
 				INFOPLIST_FILE = sentry_react_nativeTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 13.4;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.1;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -364,7 +364,7 @@
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				COPY_PHASE_STRIP = NO;
 				INFOPLIST_FILE = sentry_react_nativeTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 13.4;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.1;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -487,7 +487,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 13.4;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.1;
 				LD = "";
 				LDPLUSPLUS = "";
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -566,7 +566,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 13.4;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.1;
 				LD = "";
 				LDPLUSPLUS = "";
 				LD_RUNPATH_SEARCH_PATHS = (

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@react-navigation/native": "^6.0.8",
         "@react-navigation/native-stack": "^6.9.26",
         "@react-navigation/stack": "^6.3.21",
-        "@sentry/react-native": "^7.8.0",
+        "@sentry/react-native": "^8.8.0",
         "promise": "^8.3.0",
         "react": "19.0.0",
         "react-native": "^0.79.0",
@@ -3455,127 +3455,126 @@
       }
     },
     "node_modules/@sentry-internal/browser-utils": {
-      "version": "10.30.0",
-      "resolved": "https://registry.npmjs.org/@sentry-internal/browser-utils/-/browser-utils-10.30.0.tgz",
-      "integrity": "sha512-dVsHTUbvgaLNetWAQC6yJFnmgD0xUbVgCkmzNB7S28wIP570GcZ4cxFGPOkXbPx6dEBUfoOREeXzLqjJLtJPfg==",
+      "version": "10.48.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/browser-utils/-/browser-utils-10.48.0.tgz",
+      "integrity": "sha512-SCiTLBXzugFKxev6NoKYBIhQoDk0gUh0AVVVepCBqfCJiWBG01Zvv0R5tCVohr4cWRllkQ8mlBdNQd/I7s9tdA==",
       "license": "MIT",
       "dependencies": {
-        "@sentry/core": "10.30.0"
+        "@sentry/core": "10.48.0"
       },
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@sentry-internal/feedback": {
-      "version": "10.30.0",
-      "resolved": "https://registry.npmjs.org/@sentry-internal/feedback/-/feedback-10.30.0.tgz",
-      "integrity": "sha512-+bnQZ6SNF265nTXrRlXTmq5Ila1fRfraDOAahlOT/VM4j6zqCvNZzmeDD9J6IbxiAdhlp/YOkrG3zbr5vgYo0A==",
+      "version": "10.48.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/feedback/-/feedback-10.48.0.tgz",
+      "integrity": "sha512-tGkEyOM1HDS9qebDphUMEnyk3qq/50AnuTBiFmMJyjNzowylVGmRRk0sr3xkmbVHCDXQCiYnDmSVlJ2x4SDMrQ==",
       "license": "MIT",
       "dependencies": {
-        "@sentry/core": "10.30.0"
+        "@sentry/core": "10.48.0"
       },
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@sentry-internal/replay": {
-      "version": "10.30.0",
-      "resolved": "https://registry.npmjs.org/@sentry-internal/replay/-/replay-10.30.0.tgz",
-      "integrity": "sha512-Pj/fMIZQkXzIw6YWpxKWUE5+GXffKq6CgXwHszVB39al1wYz1gTIrTqJqt31IBLIihfCy8XxYddglR2EW0BVIQ==",
+      "version": "10.48.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/replay/-/replay-10.48.0.tgz",
+      "integrity": "sha512-sevRTePfuk4PNuz9KAKpmTZEomAU0aLXyIhOwA0OnUDdxPhkY8kq5lwDbuxTHv6DQUjUX3YgFbY45VH1JEqHKA==",
       "license": "MIT",
       "dependencies": {
-        "@sentry-internal/browser-utils": "10.30.0",
-        "@sentry/core": "10.30.0"
+        "@sentry-internal/browser-utils": "10.48.0",
+        "@sentry/core": "10.48.0"
       },
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@sentry-internal/replay-canvas": {
-      "version": "10.30.0",
-      "resolved": "https://registry.npmjs.org/@sentry-internal/replay-canvas/-/replay-canvas-10.30.0.tgz",
-      "integrity": "sha512-RIlIz+XQ4DUWaN60CjfmicJq2O2JRtDKM5lw0wB++M5ha0TBh6rv+Ojf6BDgiV3LOQ7lZvCM57xhmNUtrGmelg==",
+      "version": "10.48.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/replay-canvas/-/replay-canvas-10.48.0.tgz",
+      "integrity": "sha512-9nWuN2z4O+iwbTfuYV5ZmngBgJU/ZxfOo47A5RJP3Nu/kl59aJ1lUhILYOKyeNOIC/JyeERmpIcTxnlPXQzZ3Q==",
       "license": "MIT",
       "dependencies": {
-        "@sentry-internal/replay": "10.30.0",
-        "@sentry/core": "10.30.0"
+        "@sentry-internal/replay": "10.48.0",
+        "@sentry/core": "10.48.0"
       },
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@sentry/babel-plugin-component-annotate": {
-      "version": "4.6.1",
-      "resolved": "https://registry.npmjs.org/@sentry/babel-plugin-component-annotate/-/babel-plugin-component-annotate-4.6.1.tgz",
-      "integrity": "sha512-aSIk0vgBqv7PhX6/Eov+vlI4puCE0bRXzUG5HdCsHBpAfeMkI8Hva6kSOusnzKqs8bf04hU7s3Sf0XxGTj/1AA==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@sentry/babel-plugin-component-annotate/-/babel-plugin-component-annotate-5.2.0.tgz",
+      "integrity": "sha512-8LbOI5Kzb5F0+7LVQPi2+zGz1iPiRRFhM+7uZ/ZQ33L9BmDOYNIy3xWxCfMw2JCuMXXaxF47XCjGmR22/B0WPg==",
       "license": "MIT",
       "engines": {
-        "node": ">= 14"
+        "node": ">= 18"
       }
     },
     "node_modules/@sentry/browser": {
-      "version": "10.30.0",
-      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-10.30.0.tgz",
-      "integrity": "sha512-7M/IJUMLo0iCMLNxDV/OHTPI0WKyluxhCcxXJn7nrCcolu8A1aq9R8XjKxm0oTCO8ht5pz8bhGXUnYJj4eoEBA==",
+      "version": "10.48.0",
+      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-10.48.0.tgz",
+      "integrity": "sha512-4jt2zX2ExgFcNe2x+W+/k81fmDUsOrquGtt028CiGuDuma6kEsWBI4JbooT1jhj2T+eeUxe3YGbM23Zhh7Ghhw==",
       "license": "MIT",
       "dependencies": {
-        "@sentry-internal/browser-utils": "10.30.0",
-        "@sentry-internal/feedback": "10.30.0",
-        "@sentry-internal/replay": "10.30.0",
-        "@sentry-internal/replay-canvas": "10.30.0",
-        "@sentry/core": "10.30.0"
+        "@sentry-internal/browser-utils": "10.48.0",
+        "@sentry-internal/feedback": "10.48.0",
+        "@sentry-internal/replay": "10.48.0",
+        "@sentry-internal/replay-canvas": "10.48.0",
+        "@sentry/core": "10.48.0"
       },
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@sentry/cli": {
-      "version": "2.58.4",
-      "resolved": "https://registry.npmjs.org/@sentry/cli/-/cli-2.58.4.tgz",
-      "integrity": "sha512-ArDrpuS8JtDYEvwGleVE+FgR+qHaOp77IgdGSacz6SZy6Lv90uX0Nu4UrHCQJz8/xwIcNxSqnN22lq0dH4IqTg==",
+      "version": "3.3.5",
+      "resolved": "https://registry.npmjs.org/@sentry/cli/-/cli-3.3.5.tgz",
+      "integrity": "sha512-eyLHTj0rpeCsOUX+1ZU8UEWRXy6nXvTXNdhtAt1t6YXan9gSsAexZf28zVmDcYcP8WRbK0D2JMLp7NcaQCQgEA==",
       "hasInstallScript": true,
       "license": "FSL-1.1-MIT",
       "dependencies": {
-        "https-proxy-agent": "^5.0.0",
-        "node-fetch": "^2.6.7",
         "progress": "^2.0.3",
         "proxy-from-env": "^1.1.0",
+        "undici": "^6.22.0",
         "which": "^2.0.2"
       },
       "bin": {
         "sentry-cli": "bin/sentry-cli"
       },
       "engines": {
-        "node": ">= 10"
+        "node": ">= 18"
       },
       "optionalDependencies": {
-        "@sentry/cli-darwin": "2.58.4",
-        "@sentry/cli-linux-arm": "2.58.4",
-        "@sentry/cli-linux-arm64": "2.58.4",
-        "@sentry/cli-linux-i686": "2.58.4",
-        "@sentry/cli-linux-x64": "2.58.4",
-        "@sentry/cli-win32-arm64": "2.58.4",
-        "@sentry/cli-win32-i686": "2.58.4",
-        "@sentry/cli-win32-x64": "2.58.4"
+        "@sentry/cli-darwin": "3.3.5",
+        "@sentry/cli-linux-arm": "3.3.5",
+        "@sentry/cli-linux-arm64": "3.3.5",
+        "@sentry/cli-linux-i686": "3.3.5",
+        "@sentry/cli-linux-x64": "3.3.5",
+        "@sentry/cli-win32-arm64": "3.3.5",
+        "@sentry/cli-win32-i686": "3.3.5",
+        "@sentry/cli-win32-x64": "3.3.5"
       }
     },
     "node_modules/@sentry/cli-darwin": {
-      "version": "2.58.4",
-      "resolved": "https://registry.npmjs.org/@sentry/cli-darwin/-/cli-darwin-2.58.4.tgz",
-      "integrity": "sha512-kbTD+P4X8O+nsNwPxCywtj3q22ecyRHWff98rdcmtRrvwz8CKi/T4Jxn/fnn2i4VEchy08OWBuZAqaA5Kh2hRQ==",
+      "version": "3.3.5",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-darwin/-/cli-darwin-3.3.5.tgz",
+      "integrity": "sha512-E/SIY6+j2nt6Ri9nMt78sYle3LiF6uZyz4HGmvcEMU6HXjegmAayhy0J10JST+vZTzN6VixD8sUsa5UeJiOPcg==",
       "license": "FSL-1.1-MIT",
       "optional": true,
       "os": [
         "darwin"
       ],
       "engines": {
-        "node": ">=10"
+        "node": ">=18"
       }
     },
     "node_modules/@sentry/cli-linux-arm": {
-      "version": "2.58.4",
-      "resolved": "https://registry.npmjs.org/@sentry/cli-linux-arm/-/cli-linux-arm-2.58.4.tgz",
-      "integrity": "sha512-rdQ8beTwnN48hv7iV7e7ZKucPec5NJkRdrrycMJMZlzGBPi56LqnclgsHySJ6Kfq506A2MNuQnKGaf/sBC9REA==",
+      "version": "3.3.5",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-linux-arm/-/cli-linux-arm-3.3.5.tgz",
+      "integrity": "sha512-EGuEIvC2OQyar/vu+jAQEmovTMgxpoxdx5knnzL5dLhIemjEUNqwv/sXq+m/Aj+ThqCMofcTWB2TOZXsTtl0Tw==",
       "cpu": [
         "arm"
       ],
@@ -3587,13 +3586,13 @@
         "android"
       ],
       "engines": {
-        "node": ">=10"
+        "node": ">=18"
       }
     },
     "node_modules/@sentry/cli-linux-arm64": {
-      "version": "2.58.4",
-      "resolved": "https://registry.npmjs.org/@sentry/cli-linux-arm64/-/cli-linux-arm64-2.58.4.tgz",
-      "integrity": "sha512-0g0KwsOozkLtzN8/0+oMZoOuQ0o7W6O+hx+ydVU1bktaMGKEJLMAWxOQNjsh1TcBbNIXVOKM/I8l0ROhaAb8Ig==",
+      "version": "3.3.5",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-linux-arm64/-/cli-linux-arm64-3.3.5.tgz",
+      "integrity": "sha512-/W7HTk2OFKD0bguTvQR1ue6pkFQWaGiqPafOSIQKyq0aGfbZhBn/Uj+IRefgMZMhJQ29xRz0y/iGRGKE+ef4Vg==",
       "cpu": [
         "arm64"
       ],
@@ -3605,13 +3604,13 @@
         "android"
       ],
       "engines": {
-        "node": ">=10"
+        "node": ">=18"
       }
     },
     "node_modules/@sentry/cli-linux-i686": {
-      "version": "2.58.4",
-      "resolved": "https://registry.npmjs.org/@sentry/cli-linux-i686/-/cli-linux-i686-2.58.4.tgz",
-      "integrity": "sha512-NseoIQAFtkziHyjZNPTu1Gm1opeQHt7Wm1LbLrGWVIRvUOzlslO9/8i6wETUZ6TjlQxBVRgd3Q0lRBG2A8rFYA==",
+      "version": "3.3.5",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-linux-i686/-/cli-linux-i686-3.3.5.tgz",
+      "integrity": "sha512-qODMEWLEeUNp3IUlwwISB37EXSo8qgMmHQuLKfxDjpIKw+7NAFfptOloqPrHkLWK3TzFr+Nv643wIKZaYrz28Q==",
       "cpu": [
         "x86",
         "ia32"
@@ -3624,13 +3623,13 @@
         "android"
       ],
       "engines": {
-        "node": ">=10"
+        "node": ">=18"
       }
     },
     "node_modules/@sentry/cli-linux-x64": {
-      "version": "2.58.4",
-      "resolved": "https://registry.npmjs.org/@sentry/cli-linux-x64/-/cli-linux-x64-2.58.4.tgz",
-      "integrity": "sha512-d3Arz+OO/wJYTqCYlSN3Ktm+W8rynQ/IMtSZLK8nu0ryh5mJOh+9XlXY6oDXw4YlsM8qCRrNquR8iEI1Y/IH+Q==",
+      "version": "3.3.5",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-linux-x64/-/cli-linux-x64-3.3.5.tgz",
+      "integrity": "sha512-DCz7lQ4PySjQ1WvWOQ/uTdwauRo1D7hSHazxZ+fUAnK/epSPM9qLkjDMlD8uM5CaLoR8+ZTs7N94vV5LZs2QpA==",
       "cpu": [
         "x64"
       ],
@@ -3642,13 +3641,13 @@
         "android"
       ],
       "engines": {
-        "node": ">=10"
+        "node": ">=18"
       }
     },
     "node_modules/@sentry/cli-win32-arm64": {
-      "version": "2.58.4",
-      "resolved": "https://registry.npmjs.org/@sentry/cli-win32-arm64/-/cli-win32-arm64-2.58.4.tgz",
-      "integrity": "sha512-bqYrF43+jXdDBh0f8HIJU3tbvlOFtGyRjHB8AoRuMQv9TEDUfENZyCelhdjA+KwDKYl48R1Yasb4EHNzsoO83w==",
+      "version": "3.3.5",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-win32-arm64/-/cli-win32-arm64-3.3.5.tgz",
+      "integrity": "sha512-VMNsHiyZcP8Ft3fcK/1zoO4L66soe1eSfXg2tglFQSc/2MYA5v1Br9B1GtjBwDIc3EmdPtFZhOGLyqIzszMxJw==",
       "cpu": [
         "arm64"
       ],
@@ -3658,13 +3657,13 @@
         "win32"
       ],
       "engines": {
-        "node": ">=10"
+        "node": ">=18"
       }
     },
     "node_modules/@sentry/cli-win32-i686": {
-      "version": "2.58.4",
-      "resolved": "https://registry.npmjs.org/@sentry/cli-win32-i686/-/cli-win32-i686-2.58.4.tgz",
-      "integrity": "sha512-3triFD6jyvhVcXOmGyttf+deKZcC1tURdhnmDUIBkiDPJKGT/N5xa4qAtHJlAB/h8L9jgYih9bvJnvvFVM7yug==",
+      "version": "3.3.5",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-win32-i686/-/cli-win32-i686-3.3.5.tgz",
+      "integrity": "sha512-BE6aHOIpsm4jgavsvvXNcSikAr/8NSva3rk1N3BzoOLuX+dcFxBI60K1i2VzB1vsgtivJJo9YySNCi60dBgWTg==",
       "cpu": [
         "x86",
         "ia32"
@@ -3675,13 +3674,13 @@
         "win32"
       ],
       "engines": {
-        "node": ">=10"
+        "node": ">=18"
       }
     },
     "node_modules/@sentry/cli-win32-x64": {
-      "version": "2.58.4",
-      "resolved": "https://registry.npmjs.org/@sentry/cli-win32-x64/-/cli-win32-x64-2.58.4.tgz",
-      "integrity": "sha512-cSzN4PjM1RsCZ4pxMjI0VI7yNCkxiJ5jmWncyiwHXGiXrV1eXYdQ3n1LhUYLZ91CafyprR0OhDcE+RVZ26Qb5w==",
+      "version": "3.3.5",
+      "resolved": "https://registry.npmjs.org/@sentry/cli-win32-x64/-/cli-win32-x64-3.3.5.tgz",
+      "integrity": "sha512-MSU+PtBuiLjEbiPFOvxk4CI3TCagwkIg9kvJ+DrI3+pBY0Sga/dOyeWKTIgb01xSVcfjdw0UkpU52VCvzTT9ew==",
       "cpu": [
         "x64"
       ],
@@ -3691,27 +3690,26 @@
         "win32"
       ],
       "engines": {
-        "node": ">=10"
+        "node": ">=18"
       }
     },
     "node_modules/@sentry/core": {
-      "version": "10.30.0",
-      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-10.30.0.tgz",
-      "integrity": "sha512-IfNuqIoGVO9pwphwbOptAEJJI1SCAfewS5LBU1iL7hjPBHYAnE8tCVzyZN+pooEkQQ47Q4rGanaG1xY8mjTT1A==",
+      "version": "10.48.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-10.48.0.tgz",
+      "integrity": "sha512-h8F+fXVwYC9ro5ZaO8V+v3vqc0awlXHGblEAuVxSGgh4IV/oFX+QVzXeDTTrFOFS6v/Vn5vAyu240eJrJAS6/g==",
       "license": "MIT",
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@sentry/react": {
-      "version": "10.30.0",
-      "resolved": "https://registry.npmjs.org/@sentry/react/-/react-10.30.0.tgz",
-      "integrity": "sha512-3co0QwAU9VrCVBWgpRf/4G19MwzR+DM0sDe9tgN7P3pv/tMlEHhnPFv88nPfuSa2W8uVCpHehvV+GnUPF4V7Ag==",
+      "version": "10.48.0",
+      "resolved": "https://registry.npmjs.org/@sentry/react/-/react-10.48.0.tgz",
+      "integrity": "sha512-uc93vKjmu6gNns+JAX4qquuxWpAMit0uGPA1TYlMjct9NG1uX3TkDPJAr9Pgd1lOXx8mKqCmj5fK33QeExMpPw==",
       "license": "MIT",
       "dependencies": {
-        "@sentry/browser": "10.30.0",
-        "@sentry/core": "10.30.0",
-        "hoist-non-react-statics": "^3.3.2"
+        "@sentry/browser": "10.48.0",
+        "@sentry/core": "10.48.0"
       },
       "engines": {
         "node": ">=18"
@@ -3721,19 +3719,22 @@
       }
     },
     "node_modules/@sentry/react-native": {
-      "version": "7.8.0",
-      "resolved": "https://registry.npmjs.org/@sentry/react-native/-/react-native-7.8.0.tgz",
-      "integrity": "sha512-0YMD0ObuGPbJVfHCBaYTfmRtS7tUd64W2GMNPA3b6rGlVlMQlL7bfdkCUouVBZzFDJYLV8ik1PzJKPWunKHCvw==",
+      "version": "8.8.0",
+      "resolved": "https://registry.npmjs.org/@sentry/react-native/-/react-native-8.8.0.tgz",
+      "integrity": "sha512-Qsb/Bnuf6mOeDEtM56jZYzvENMDPX3btCVNHt9MG4LDLKr4iQfRPmUX9+WwnAmEoAlJkBQJlFQLCXApXEB1LEA==",
       "license": "MIT",
       "dependencies": {
-        "@sentry/babel-plugin-component-annotate": "4.6.1",
-        "@sentry/browser": "10.30.0",
-        "@sentry/cli": "2.58.4",
-        "@sentry/core": "10.30.0",
-        "@sentry/react": "10.30.0",
-        "@sentry/types": "10.30.0"
+        "@sentry/babel-plugin-component-annotate": "5.2.0",
+        "@sentry/browser": "10.48.0",
+        "@sentry/cli": "3.3.5",
+        "@sentry/core": "10.48.0",
+        "@sentry/react": "10.48.0",
+        "@sentry/types": "10.48.0"
       },
       "bin": {
+        "sentry-eas-build-on-complete": "scripts/eas-build-hook.js",
+        "sentry-eas-build-on-error": "scripts/eas-build-hook.js",
+        "sentry-eas-build-on-success": "scripts/eas-build-hook.js",
         "sentry-expo-upload-sourcemaps": "scripts/expo-upload-sourcemaps.js"
       },
       "peerDependencies": {
@@ -3748,12 +3749,12 @@
       }
     },
     "node_modules/@sentry/types": {
-      "version": "10.30.0",
-      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-10.30.0.tgz",
-      "integrity": "sha512-tSyzG/JunWjbuQDDwP3DKgt8KP23ZSuNUEudMSv2jCF/956o8ksamPeidCTSVMXoEyTt5tvimWNeNvUFIFq3EA==",
+      "version": "10.48.0",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-10.48.0.tgz",
+      "integrity": "sha512-HiguzLr+vlor1ky0rpWHmZoravFsnx65kXqB94yqYMo7V3QgSOPzWrOjv518a2yZc/1boufQ3LINq6ZDhO2l1g==",
       "license": "MIT",
       "dependencies": {
-        "@sentry/core": "10.30.0"
+        "@sentry/core": "10.48.0"
       },
       "engines": {
         "node": ">=18"
@@ -4281,18 +4282,6 @@
       "license": "MIT",
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
-      }
-    },
-    "node_modules/agent-base": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
-      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
-      "license": "MIT",
-      "dependencies": {
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 6.0.0"
       }
     },
     "node_modules/ajv": {
@@ -7314,19 +7303,6 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/https-proxy-agent": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
-      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
-      "license": "MIT",
-      "dependencies": {
-        "agent-base": "6",
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
     "node_modules/human-signals": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
@@ -9733,26 +9709,6 @@
         "node": ">=12.0.0"
       }
     },
-    "node_modules/node-fetch": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
-      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
-      "license": "MIT",
-      "dependencies": {
-        "whatwg-url": "^5.0.0"
-      },
-      "engines": {
-        "node": "4.x || >=6.0.0"
-      },
-      "peerDependencies": {
-        "encoding": "^0.1.0"
-      },
-      "peerDependenciesMeta": {
-        "encoding": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/node-int64": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
@@ -12021,12 +11977,6 @@
         "node": ">=0.6"
       }
     },
-    "node_modules/tr46": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
-      "license": "MIT"
-    },
     "node_modules/ts-api-utils": {
       "version": "1.4.3",
       "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.4.3.tgz",
@@ -12254,7 +12204,7 @@
       "version": "5.0.4",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.0.4.tgz",
       "integrity": "sha512-cW9T5W9xY37cc+jfEnaUvX91foxtHkza3Nw3wkoF4sSlKn0MONdkdEndig/qPBWXNkmplh3NzayQzCiHM4/hqw==",
-      "dev": true,
+      "devOptional": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -12276,6 +12226,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/undici": {
+      "version": "6.25.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.25.0.tgz",
+      "integrity": "sha512-ZgpWDC5gmNiuY9CnLVXEH8rl50xhRCuLNA97fAUnKi8RRuV4E6KG31pDTsLVUKnohJE0I3XDrTeEydAXRw47xg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.17"
       }
     },
     "node_modules/unicode-canonical-property-names-ecmascript": {
@@ -12467,26 +12426,10 @@
         "defaults": "^1.0.3"
       }
     },
-    "node_modules/webidl-conversions": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
-      "license": "BSD-2-Clause"
-    },
     "node_modules/whatwg-fetch": {
       "version": "3.6.18",
       "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.6.18.tgz",
       "integrity": "sha512-ltN7j66EneWn5TFDO4L9inYC1D+Czsxlrw2SalgjMmEMkLfA5SIZxEFdE6QtHFiiM6Q7WL32c7AkI3w6yxM84Q=="
-    },
-    "node_modules/whatwg-url": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
-      "license": "MIT",
-      "dependencies": {
-        "tr46": "~0.0.3",
-        "webidl-conversions": "^3.0.0"
-      }
     },
     "node_modules/which": {
       "version": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "@react-navigation/native": "^6.0.8",
     "@react-navigation/native-stack": "^6.9.26",
     "@react-navigation/stack": "^6.3.21",
-    "@sentry/react-native": "^7.8.0",
+    "@sentry/react-native": "^8.8.0",
     "promise": "^8.3.0",
     "react": "19.0.0",
     "react-native": "^0.79.0",

--- a/src/screens/EndToEndTestsScreen.tsx
+++ b/src/screens/EndToEndTestsScreen.tsx
@@ -18,7 +18,7 @@ const EndToEndTestsScreen = () => {
   React.useEffect(() => {
     Sentry.init({
       dsn: DSN,
-      beforeSend: (e: Sentry.Event) => {
+      beforeSend: (e: Sentry.ErrorEvent) => {
         setEventId(e.event_id);
         return e;
       },


### PR DESCRIPTION
Upgrades the Sentry RN SDK to v8, which pulls in Cocoa SDK v9 and Sentry Android Gradle Plugin v6. Per the [v7 → v8 migration guide](https://docs.sentry.io/platforms/react-native/migration/v7-to-v8/), this requires matching bumps to our iOS deployment target and Android build tooling.

Changes

- ios/Podfile.lock — Regenerated. RNSentry 7.8.0 → 8.8.0, and Sentry/HybridSDK 8.57.3 → Sentry 9.10.0 per the [Cocoa v9 upgrade](https://docs.sentry.io/platforms/react-native/migration/v7-to-v8/#important-changes-in-dependencies).
- ios/sentry_react_native.xcodeproj/project.pbxproj — IPHONEOS_DEPLOYMENT_TARGET 13.4 → 15.1 (app + test targets, Debug + Release). Required by the new [iOS 15.0+ minimum](https://docs.sentry.io/platforms/react-native/migration/v7-to-v8/#iosmacostvos).
- android/build.gradle — sentry-android-gradle-plugin 3.12.0 → 6.0.0, required by v8 ([Android section](https://docs.sentry.io/platforms/react-native/migration/v7-to-v8/#android)).
- src/screens/EndToEndTestsScreen.tsx — beforeSend param typed as `Sentry.ErrorEvent` instead of `Sentry.Event` to match the v8 type signature.
- package-lock.json — Regenerated for the new dependency tree.
- Bumped iOS CI runner from macos-14 to macos-15 so builds use Xcode 16.4 (the macos-15 default). This fixes the module '_SentryPrivate' not found failure

Test plan

- [ ]  iOS build succeeds in Xcode 16.4+ targeting iOS 15.1+
- [ ]  Android build succeeds with Sentry AGP 6.0.0
- [ ]  JS error, native iOS crash, and native Android crash all reach Sentry